### PR TITLE
Adapt Qt polynomial UI to parse algebraic expressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(SparsePolynomialCalculator VERSION 1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+# Prefer Qt6 but allow falling back to Qt5 if necessary.
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
+
+set(PROJECT_SOURCES
+    main.cpp
+    mainwindow.cpp
+    mainwindow.h
+    mainwindow.ui
+    polynomial.cpp
+    polynomial.h
+)
+
+add_executable(${PROJECT_NAME}
+    ${PROJECT_SOURCES}
+)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
+
+# Ensure that the headers in this directory are visible to consumers.
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/main.cpp
+++ b/main.cpp
@@ -1,9 +1,13 @@
 #include <QApplication>
+#include <QCoreApplication>
+#include <QString>
 
 #include "mainwindow.h"
 
 int main(int argc, char* argv[]) {
     QApplication app(argc, argv);
+    QCoreApplication::setApplicationName(QStringLiteral("一元稀疏多项式简单计算器"));
+    QCoreApplication::setApplicationVersion(QStringLiteral("1.0"));
     MainWindow window;
     window.show();
     return app.exec();

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,10 @@
+#include <QApplication>
+
+#include "mainwindow.h"
+
+int main(int argc, char* argv[]) {
+    QApplication app(argc, argv);
+    MainWindow window;
+    window.show();
+    return app.exec();
+}

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -50,6 +50,7 @@ bool MainWindow::readValue(long double& value) {
 void MainWindow::displayPolynomialDetails(const QString& name, const Polynomial& polynomial) {
     appendMessage(tr("%1: %2").arg(name, polynomial.toExpressionString()));
     appendMessage(tr("%1 的稀疏序列: %2").arg(name, polynomial.toSequenceString()));
+    appendMessage(QString());
 }
 
 QString MainWindow::formatNumber(long double number) const {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -58,7 +58,7 @@ QString MainWindow::formatNumber(long double number) const {
 }
 
 void MainWindow::buildPolynomialA() {
-    QString text = ui->inputA->text();
+    QString text = ui->inputA->text().trimmed();
     if (polynomialA.parseFromString(text)) {
         hasA = true;
         appendMessage(tr("多项式 A 构建成功。"));
@@ -68,12 +68,12 @@ void MainWindow::buildPolynomialA() {
         displayPolynomialDetails(tr("多项式 A"), polynomialA);
     } else {
         hasA = false;
-        appendMessage(tr("多项式 A 输入无效。"));
+        appendMessage(tr("多项式 A 输入无效，请确认使用形如 (2-3x^4+4x^34) 的表达式并按降幂排列。"));
     }
 }
 
 void MainWindow::buildPolynomialB() {
-    QString text = ui->inputB->text();
+    QString text = ui->inputB->text().trimmed();
     if (polynomialB.parseFromString(text)) {
         hasB = true;
         appendMessage(tr("多项式 B 构建成功。"));
@@ -83,7 +83,7 @@ void MainWindow::buildPolynomialB() {
         displayPolynomialDetails(tr("多项式 B"), polynomialB);
     } else {
         hasB = false;
-        appendMessage(tr("多项式 B 输入无效。"));
+        appendMessage(tr("多项式 B 输入无效，请确认使用形如 (2-3x^4+4x^34) 的表达式并按降幂排列。"));
     }
 }
 
@@ -132,6 +132,7 @@ void MainWindow::evaluatePolynomialA() {
     }
     long double result = polynomialA.evaluate(value);
     appendMessage(tr("A(%1) = %2").arg(formatNumber(value), formatNumber(result)));
+    appendMessage(QString());
 }
 
 void MainWindow::evaluatePolynomialB() {
@@ -145,4 +146,5 @@ void MainWindow::evaluatePolynomialB() {
     }
     long double result = polynomialB.evaluate(value);
     appendMessage(tr("B(%1) = %2").arg(formatNumber(value), formatNumber(result)));
+    appendMessage(QString());
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1,0 +1,132 @@
+#include "mainwindow.h"
+
+#include "ui_mainwindow.h"
+
+#include <QLabel>
+#include <QPushButton>
+
+using namespace std;
+
+MainWindow::MainWindow(QWidget* parent)
+    : QMainWindow(parent), ui(new Ui::MainWindow), hasA(false), hasB(false) {
+    ui->setupUi(this);
+
+    setMinimumSize(640, 480);
+
+    connect(ui->buildAButton, &QPushButton::clicked, this, &MainWindow::buildPolynomialA);
+    connect(ui->buildBButton, &QPushButton::clicked, this, &MainWindow::buildPolynomialB);
+    connect(ui->showAButton, &QPushButton::clicked, this, &MainWindow::showPolynomialA);
+    connect(ui->showBButton, &QPushButton::clicked, this, &MainWindow::showPolynomialB);
+    connect(ui->addButton, &QPushButton::clicked, this, &MainWindow::addPolynomials);
+    connect(ui->subtractButton, &QPushButton::clicked, this, &MainWindow::subtractPolynomials);
+    connect(ui->evalAButton, &QPushButton::clicked, this, &MainWindow::evaluatePolynomialA);
+    connect(ui->evalBButton, &QPushButton::clicked, this, &MainWindow::evaluatePolynomialB);
+}
+
+MainWindow::~MainWindow() {
+    delete ui;
+}
+
+void MainWindow::appendMessage(const QString& message) {
+    ui->outputArea->append(message);
+}
+
+bool MainWindow::readValue(long double& value) {
+    QString text = ui->valueInput->text().trimmed();
+    if (text.isEmpty()) {
+        appendMessage(tr("请先输入 x 的值。"));
+        return false;
+    }
+    bool ok = false;
+    long double parsed = static_cast<long double>(text.toDouble(&ok));
+    if (!ok) {
+        appendMessage(tr("无法解析 x 的值，请重新输入。"));
+        return false;
+    }
+    value = parsed;
+    return true;
+}
+
+void MainWindow::buildPolynomialA() {
+    QString text = ui->inputA->text();
+    if (polynomialA.parseFromString(text)) {
+        hasA = true;
+        appendMessage(tr("多项式 A 构建成功: %1").arg(polynomialA.toExpressionString()));
+    } else {
+        hasA = false;
+        appendMessage(tr("多项式 A 输入无效。"));
+    }
+}
+
+void MainWindow::buildPolynomialB() {
+    QString text = ui->inputB->text();
+    if (polynomialB.parseFromString(text)) {
+        hasB = true;
+        appendMessage(tr("多项式 B 构建成功: %1").arg(polynomialB.toExpressionString()));
+    } else {
+        hasB = false;
+        appendMessage(tr("多项式 B 输入无效。"));
+    }
+}
+
+void MainWindow::showPolynomialA() {
+    if (!hasA) {
+        appendMessage(tr("请先建立多项式 A。"));
+        return;
+    }
+    appendMessage(tr("多项式 A: %1").arg(polynomialA.toExpressionString()));
+}
+
+void MainWindow::showPolynomialB() {
+    if (!hasB) {
+        appendMessage(tr("请先建立多项式 B。"));
+        return;
+    }
+    appendMessage(tr("多项式 B: %1").arg(polynomialB.toExpressionString()));
+}
+
+void MainWindow::addPolynomials() {
+    if (!hasA || !hasB) {
+        appendMessage(tr("请先建立多项式 A 和 B。"));
+        return;
+    }
+    Polynomial result = polynomialA.add(polynomialB);
+    appendMessage(tr("A + B: %1").arg(result.toExpressionString()));
+}
+
+void MainWindow::subtractPolynomials() {
+    if (!hasA || !hasB) {
+        appendMessage(tr("请先建立多项式 A 和 B。"));
+        return;
+    }
+    Polynomial result = polynomialA.subtract(polynomialB);
+    appendMessage(tr("A - B: %1").arg(result.toExpressionString()));
+}
+
+void MainWindow::evaluatePolynomialA() {
+    if (!hasA) {
+        appendMessage(tr("请先建立多项式 A。"));
+        return;
+    }
+    long double value = 0.0L;
+    if (!readValue(value)) {
+        return;
+    }
+    long double result = polynomialA.evaluate(value);
+    appendMessage(tr("A(%1) = %2").arg(QString::number(static_cast<double>(value)),
+                                     QString::number(static_cast<double>(result))));
+}
+
+void MainWindow::evaluatePolynomialB() {
+    if (!hasB) {
+        appendMessage(tr("请先建立多项式 B。"));
+        return;
+    }
+    long double value = 0.0L;
+    if (!readValue(value)) {
+        return;
+    }
+    long double result = polynomialB.evaluate(value);
+    appendMessage(tr("B(%1) = %2").arg(QString::number(static_cast<double>(value)),
+                                     QString::number(static_cast<double>(result))));
+}

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -62,6 +62,9 @@ void MainWindow::buildPolynomialA() {
     if (polynomialA.parseFromString(text)) {
         hasA = true;
         appendMessage(tr("多项式 A 构建成功。"));
+        if (polynomialA.isEmpty()) {
+            appendMessage(tr("多项式 A 是零多项式。"));
+        }
         displayPolynomialDetails(tr("多项式 A"), polynomialA);
     } else {
         hasA = false;
@@ -74,6 +77,9 @@ void MainWindow::buildPolynomialB() {
     if (polynomialB.parseFromString(text)) {
         hasB = true;
         appendMessage(tr("多项式 B 构建成功。"));
+        if (polynomialB.isEmpty()) {
+            appendMessage(tr("多项式 B 是零多项式。"));
+        }
         displayPolynomialDetails(tr("多项式 B"), polynomialB);
     } else {
         hasB = false;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -47,11 +47,21 @@ bool MainWindow::readValue(long double& value) {
     return true;
 }
 
+void MainWindow::displayPolynomialDetails(const QString& name, const Polynomial& polynomial) {
+    appendMessage(tr("%1: %2").arg(name, polynomial.toExpressionString()));
+    appendMessage(tr("%1 的稀疏序列: %2").arg(name, polynomial.toSequenceString()));
+}
+
+QString MainWindow::formatNumber(long double number) const {
+    return QString::number(static_cast<double>(number), 'g', 15);
+}
+
 void MainWindow::buildPolynomialA() {
     QString text = ui->inputA->text();
     if (polynomialA.parseFromString(text)) {
         hasA = true;
-        appendMessage(tr("多项式 A 构建成功: %1").arg(polynomialA.toExpressionString()));
+        appendMessage(tr("多项式 A 构建成功。"));
+        displayPolynomialDetails(tr("多项式 A"), polynomialA);
     } else {
         hasA = false;
         appendMessage(tr("多项式 A 输入无效。"));
@@ -62,7 +72,8 @@ void MainWindow::buildPolynomialB() {
     QString text = ui->inputB->text();
     if (polynomialB.parseFromString(text)) {
         hasB = true;
-        appendMessage(tr("多项式 B 构建成功: %1").arg(polynomialB.toExpressionString()));
+        appendMessage(tr("多项式 B 构建成功。"));
+        displayPolynomialDetails(tr("多项式 B"), polynomialB);
     } else {
         hasB = false;
         appendMessage(tr("多项式 B 输入无效。"));
@@ -74,7 +85,7 @@ void MainWindow::showPolynomialA() {
         appendMessage(tr("请先建立多项式 A。"));
         return;
     }
-    appendMessage(tr("多项式 A: %1").arg(polynomialA.toExpressionString()));
+    displayPolynomialDetails(tr("多项式 A"), polynomialA);
 }
 
 void MainWindow::showPolynomialB() {
@@ -82,7 +93,7 @@ void MainWindow::showPolynomialB() {
         appendMessage(tr("请先建立多项式 B。"));
         return;
     }
-    appendMessage(tr("多项式 B: %1").arg(polynomialB.toExpressionString()));
+    displayPolynomialDetails(tr("多项式 B"), polynomialB);
 }
 
 void MainWindow::addPolynomials() {
@@ -91,7 +102,7 @@ void MainWindow::addPolynomials() {
         return;
     }
     Polynomial result = polynomialA.add(polynomialB);
-    appendMessage(tr("A + B: %1").arg(result.toExpressionString()));
+    displayPolynomialDetails(tr("A + B"), result);
 }
 
 void MainWindow::subtractPolynomials() {
@@ -100,7 +111,7 @@ void MainWindow::subtractPolynomials() {
         return;
     }
     Polynomial result = polynomialA.subtract(polynomialB);
-    appendMessage(tr("A - B: %1").arg(result.toExpressionString()));
+    displayPolynomialDetails(tr("A - B"), result);
 }
 
 void MainWindow::evaluatePolynomialA() {
@@ -113,8 +124,7 @@ void MainWindow::evaluatePolynomialA() {
         return;
     }
     long double result = polynomialA.evaluate(value);
-    appendMessage(tr("A(%1) = %2").arg(QString::number(static_cast<double>(value)),
-                                     QString::number(static_cast<double>(result))));
+    appendMessage(tr("A(%1) = %2").arg(formatNumber(value), formatNumber(result)));
 }
 
 void MainWindow::evaluatePolynomialB() {
@@ -127,6 +137,5 @@ void MainWindow::evaluatePolynomialB() {
         return;
     }
     long double result = polynomialB.evaluate(value);
-    appendMessage(tr("B(%1) = %2").arg(QString::number(static_cast<double>(value)),
-                                     QString::number(static_cast<double>(result))));
+    appendMessage(tr("B(%1) = %2").arg(formatNumber(value), formatNumber(result)));
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -35,6 +35,8 @@ private:
 
     void appendMessage(const QString& message);
     bool readValue(long double& value);
+    void displayPolynomialDetails(const QString& name, const Polynomial& polynomial);
+    QString formatNumber(long double number) const;
 };
 
 #endif // MAINWINDOW_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -1,0 +1,40 @@
+#ifndef MAINWINDOW_H
+#define MAINWINDOW_H
+
+#include <QMainWindow>
+
+#include "polynomial.h"
+
+namespace Ui {
+class MainWindow;
+}
+
+class MainWindow : public QMainWindow {
+    Q_OBJECT
+
+public:
+    explicit MainWindow(QWidget* parent = nullptr);
+    ~MainWindow() override;
+
+private slots:
+    void buildPolynomialA();
+    void buildPolynomialB();
+    void showPolynomialA();
+    void showPolynomialB();
+    void addPolynomials();
+    void subtractPolynomials();
+    void evaluatePolynomialA();
+    void evaluatePolynomialB();
+
+private:
+    Ui::MainWindow* ui;
+    Polynomial polynomialA;
+    Polynomial polynomialB;
+    bool hasA;
+    bool hasB;
+
+    void appendMessage(const QString& message);
+    bool readValue(long double& value);
+};
+
+#endif // MAINWINDOW_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -2,6 +2,7 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
+#include <QString>
 
 #include "polynomial.h"
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>一元稀疏多项式简单计算器</string>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QLabel" name="titleLabel">
+      <property name="text">
+       <string>一元稀疏多项式简单计算器</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QLabel" name="instructionsLabel">
+      <property name="text">
+       <string>输入格式: 使用降幂排列的表达式, 例如: 3+2x+3x^4-340x^34&#xa;输出: 所有计算结果会显示在下方的文本框中。</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="layoutA">
+      <item>
+       <widget class="QLabel" name="labelA">
+        <property name="text">
+         <string>多项式 A:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="inputA">
+        <property name="placeholderText">
+         <string>例如: 3+2x+3x^4-340x^34</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="buildAButton">
+        <property name="text">
+         <string>建立多项式 A</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="layoutB">
+      <item>
+       <widget class="QLabel" name="labelB">
+        <property name="text">
+         <string>多项式 B:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="inputB">
+        <property name="placeholderText">
+         <string>例如: 1-4x+6x^2</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="buildBButton">
+        <property name="text">
+         <string>建立多项式 B</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="layoutActions">
+      <item>
+       <widget class="QPushButton" name="showAButton">
+        <property name="text">
+         <string>输出 A</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="showBButton">
+        <property name="text">
+         <string>输出 B</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="addButton">
+        <property name="text">
+         <string>A + B</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="subtractButton">
+        <property name="text">
+         <string>A - B</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="layoutValue">
+      <item>
+       <widget class="QLabel" name="labelValue">
+        <property name="text">
+         <string>x 的值:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="valueInput">
+        <property name="placeholderText">
+         <string>请输入一个数字</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="evalAButton">
+        <property name="text">
+         <string>计算 A(x)</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="evalBButton">
+        <property name="text">
+         <string>计算 B(x)</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <widget class="QTextEdit" name="outputArea">
+      <property name="readOnly">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QMenuBar" name="menubar"/>
+  <widget class="QStatusBar" name="statusbar"/>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -28,7 +28,7 @@
     <item>
      <widget class="QLabel" name="instructionsLabel">
       <property name="text">
-       <string>输入格式: 使用降幂排列的表达式, 例如: 3+2x+3x^4-340x^34&#xa;输出: 结果会以表达式和 n c e... 的稀疏序列形式显示在下方文本框中。</string>
+       <string>输入格式: 使用括号包裹的降幂表达式, 例如: (3+2x+3x^4-340x^34)&#xa;输出: 结果会以表达式和 n c e... 的稀疏序列形式显示在下方文本框中。</string>
       </property>
       <property name="wordWrap">
        <bool>true</bool>
@@ -47,7 +47,7 @@
       <item>
        <widget class="QLineEdit" name="inputA">
         <property name="placeholderText">
-         <string>例如: 3+2x+3x^4-340x^34</string>
+         <string>例如: (3+2x+3x^4-340x^34)</string>
         </property>
        </widget>
       </item>
@@ -72,7 +72,7 @@
       <item>
        <widget class="QLineEdit" name="inputB">
         <property name="placeholderText">
-         <string>例如: 1-4x+6x^2</string>
+         <string>例如: (1-4x+6x^2)</string>
         </property>
        </widget>
       </item>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -28,7 +28,7 @@
     <item>
      <widget class="QLabel" name="instructionsLabel">
       <property name="text">
-       <string>输入格式: 使用降幂排列的表达式, 例如: 3+2x+3x^4-340x^34&#xa;输出: 所有计算结果会显示在下方的文本框中。</string>
+       <string>输入格式: 使用降幂排列的表达式, 例如: 3+2x+3x^4-340x^34&#xa;输出: 结果会以表达式和 n,c,e... 稀疏序列的形式显示在下方文本框中。</string>
       </property>
       <property name="wordWrap">
        <bool>true</bool>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -28,7 +28,7 @@
     <item>
      <widget class="QLabel" name="instructionsLabel">
       <property name="text">
-       <string>输入格式: 使用降幂排列的表达式, 例如: 3+2x+3x^4-340x^34&#xa;输出: 结果会以表达式和 n,c,e... 稀疏序列的形式显示在下方文本框中。</string>
+       <string>输入格式: 使用降幂排列的表达式, 例如: 3+2x+3x^4-340x^34&#xa;输出: 结果会以表达式和 n c e... 的稀疏序列形式显示在下方文本框中。</string>
       </property>
       <property name="wordWrap">
        <bool>true</bool>

--- a/polynomial.cpp
+++ b/polynomial.cpp
@@ -267,10 +267,29 @@ long double Polynomial::evaluate(long double x) const {
     long double total = 0.0L;
     for (Term* current = head; current != nullptr; current = current->next) {
         long double coef = static_cast<long double>(current->coefficient);
-        long double exp = static_cast<long double>(current->exponent);
-        total += coef * pow(x, exp);
+        total += coef * power(x, current->exponent);
     }
     return total;
+}
+
+long double Polynomial::power(long double base, long long exponent) {
+    if (exponent == 0) {
+        return 1.0L;
+    }
+
+    long double result = 1.0L;
+    long double factor = base;
+    long long remaining = exponent;
+
+    while (remaining > 0) {
+        if ((remaining & 1LL) != 0) {
+            result *= factor;
+        }
+        factor *= factor;
+        remaining >>= 1;
+    }
+
+    return result;
 }
 
 void Polynomial::clear() {

--- a/polynomial.cpp
+++ b/polynomial.cpp
@@ -1,0 +1,328 @@
+#include <QTextStream>
+#include "polynomial.h"
+
+Polynomial::Polynomial() : head(nullptr) {}
+
+Polynomial::Polynomial(const QString& text) : head(nullptr) {
+    parseFromString(text);
+}
+
+Polynomial::Polynomial(const string& text) : head(nullptr) {
+    parseFromString(QString::fromStdString(text));
+}
+
+Polynomial::Polynomial(const Polynomial& other) : head(nullptr) {
+    copyFrom(other);
+}
+
+Polynomial::Polynomial(Polynomial&& other) noexcept : head(other.head) {
+    other.head = nullptr;
+}
+
+Polynomial& Polynomial::operator=(const Polynomial& other) {
+    if (this != &other) {
+        clear();
+        copyFrom(other);
+    }
+    return *this;
+}
+
+Polynomial& Polynomial::operator=(Polynomial&& other) noexcept {
+    if (this != &other) {
+        clear();
+        head = other.head;
+        other.head = nullptr;
+    }
+    return *this;
+}
+
+Polynomial::~Polynomial() {
+    clear();
+}
+
+bool Polynomial::isEmpty() const {
+    return head == nullptr;
+}
+
+bool Polynomial::parseFromString(const QString& text) {
+    clear();
+
+    QString sanitized;
+    sanitized.reserve(text.size());
+    for (QChar ch : text) {
+        if (!ch.isSpace()) {
+            sanitized.append(ch);
+        }
+    }
+
+    if (sanitized.isEmpty()) {
+        return true;
+    }
+
+    int length = sanitized.size();
+    int index = 0;
+    bool parsedAny = false;
+
+    while (index < length) {
+        int sign = 1;
+        if (sanitized[index] == '+') {
+            ++index;
+        } else if (sanitized[index] == '-') {
+            sign = -1;
+            ++index;
+        } else if (parsedAny) {
+            clear();
+            return false;
+        }
+
+        if (index >= length) {
+            clear();
+            return false;
+        }
+
+        QString coefPart;
+        while (index < length && sanitized[index].isDigit()) {
+            coefPart.append(sanitized[index]);
+            ++index;
+        }
+
+        bool hasVariable = false;
+        if (index < length && (sanitized[index] == 'x' || sanitized[index] == 'X')) {
+            hasVariable = true;
+            ++index;
+        }
+
+        long long exponent = 0;
+        if (hasVariable) {
+            exponent = 1;
+            if (index < length && sanitized[index] == '^') {
+                ++index;
+                QString exponentPart;
+                while (index < length && sanitized[index].isDigit()) {
+                    exponentPart.append(sanitized[index]);
+                    ++index;
+                }
+                if (exponentPart.isEmpty()) {
+                    clear();
+                    return false;
+                }
+                bool okExp = false;
+                long long parsedExp = exponentPart.toLongLong(&okExp);
+                if (!okExp || parsedExp < 0) {
+                    clear();
+                    return false;
+                }
+                exponent = parsedExp;
+            }
+        } else if (coefPart.isEmpty()) {
+            clear();
+            return false;
+        }
+
+        long long coefficient = 0;
+        if (coefPart.isEmpty()) {
+            coefficient = sign;
+        } else {
+            bool okCoef = false;
+            long long parsedCoef = coefPart.toLongLong(&okCoef);
+            if (!okCoef) {
+                clear();
+                return false;
+            }
+            coefficient = parsedCoef * sign;
+        }
+
+        if (!hasVariable) {
+            exponent = 0;
+        }
+
+        if (coefficient != 0) {
+            insertTerm(coefficient, exponent);
+        }
+
+        parsedAny = true;
+
+        if (index < length && sanitized[index] != '+' && sanitized[index] != '-') {
+            clear();
+            return false;
+        }
+    }
+
+    return true;
+}
+
+QString Polynomial::toExpressionString() const {
+    if (head == nullptr) {
+        return QStringLiteral("0");
+    }
+
+    QString result;
+    QTextStream stream(&result);
+    Term* current = head;
+    bool first = true;
+
+    while (current != nullptr) {
+        long long coefficient = current->coefficient;
+        long long exponent = current->exponent;
+
+        if (first) {
+            if (coefficient < 0) {
+                stream << '-';
+            }
+        } else {
+            stream << (coefficient < 0 ? '-' : '+');
+        }
+
+        long long absCoef = coefficient < 0 ? -coefficient : coefficient;
+        bool showCoefficient = !(absCoef == 1 && exponent != 0);
+
+        if (showCoefficient) {
+            stream << absCoef;
+        }
+
+        if (exponent != 0) {
+            stream << 'x';
+            if (exponent != 1) {
+                stream << '^' << exponent;
+            }
+        }
+
+        first = false;
+        current = current->next;
+    }
+
+    return result;
+}
+
+Polynomial Polynomial::add(const Polynomial& other) const {
+    Polynomial output;
+    Term* lhs = head;
+    Term* rhs = other.head;
+
+    while (lhs != nullptr || rhs != nullptr) {
+        if (rhs == nullptr || (lhs != nullptr && lhs->exponent > rhs->exponent)) {
+            output.insertTerm(lhs->coefficient, lhs->exponent);
+            lhs = lhs->next;
+        } else if (lhs == nullptr || rhs->exponent > lhs->exponent) {
+            output.insertTerm(rhs->coefficient, rhs->exponent);
+            rhs = rhs->next;
+        } else {
+            long long sum = lhs->coefficient + rhs->coefficient;
+            if (sum != 0) {
+                output.insertTerm(sum, lhs->exponent);
+            }
+            lhs = lhs->next;
+            rhs = rhs->next;
+        }
+    }
+
+    return output;
+}
+
+Polynomial Polynomial::subtract(const Polynomial& other) const {
+    Polynomial output;
+    Term* lhs = head;
+    Term* rhs = other.head;
+
+    while (lhs != nullptr || rhs != nullptr) {
+        if (rhs == nullptr || (lhs != nullptr && lhs->exponent > rhs->exponent)) {
+            output.insertTerm(lhs->coefficient, lhs->exponent);
+            lhs = lhs->next;
+        } else if (lhs == nullptr || rhs->exponent > lhs->exponent) {
+            output.insertTerm(-rhs->coefficient, rhs->exponent);
+            rhs = rhs->next;
+        } else {
+            long long diff = lhs->coefficient - rhs->coefficient;
+            if (diff != 0) {
+                output.insertTerm(diff, lhs->exponent);
+            }
+            lhs = lhs->next;
+            rhs = rhs->next;
+        }
+    }
+
+    return output;
+}
+
+long double Polynomial::evaluate(long double x) const {
+    long double total = 0.0L;
+    for (Term* current = head; current != nullptr; current = current->next) {
+        long double coef = static_cast<long double>(current->coefficient);
+        long double exp = static_cast<long double>(current->exponent);
+        total += coef * pow(x, exp);
+    }
+    return total;
+}
+
+void Polynomial::clear() {
+    Term* current = head;
+    while (current != nullptr) {
+        Term* nextNode = current->next;
+        delete current;
+        current = nextNode;
+    }
+    head = nullptr;
+}
+
+void Polynomial::copyFrom(const Polynomial& other) {
+    Term* current = other.head;
+    while (current != nullptr) {
+        insertTerm(current->coefficient, current->exponent);
+        current = current->next;
+    }
+}
+
+int Polynomial::countTerms() const {
+    int count = 0;
+    for (Term* current = head; current != nullptr; current = current->next) {
+        ++count;
+    }
+    return count;
+}
+
+void Polynomial::insertTerm(long long coefficient, long long exponent) {
+    if (coefficient == 0) {
+        return;
+    }
+
+    Term* newTerm = new Term{coefficient, exponent, nullptr};
+
+    if (head == nullptr || head->exponent < exponent) {
+        newTerm->next = head;
+        head = newTerm;
+        return;
+    }
+
+    Term* current = head;
+    Term* previous = nullptr;
+
+    while (current != nullptr && current->exponent > exponent) {
+        previous = current;
+        current = current->next;
+    }
+
+    if (current != nullptr && current->exponent == exponent) {
+        long long combined = current->coefficient + coefficient;
+        if (combined == 0) {
+            if (previous == nullptr) {
+                head = current->next;
+            } else {
+                previous->next = current->next;
+            }
+            delete current;
+            delete newTerm;
+        } else {
+            current->coefficient = combined;
+            delete newTerm;
+        }
+        return;
+    }
+
+    if (previous == nullptr) {
+        newTerm->next = head;
+        head = newTerm;
+    } else {
+        newTerm->next = previous->next;
+        previous->next = newTerm;
+    }
+}

--- a/polynomial.cpp
+++ b/polynomial.cpp
@@ -59,7 +59,40 @@ bool Polynomial::parseFromString(const QString& text) {
         return true;
     }
 
-    int length = sanitized.size();
+    // Remove wrapping parentheses that enclose the entire expression.
+    bool trimmed = true;
+    while (trimmed && sanitized.size() >= 2 && sanitized.front() == '(' && sanitized.back() == ')') {
+        trimmed = false;
+        int depth = 0;
+        bool encloses = true;
+        for (int i = 0; i < sanitized.size() - 1; ++i) {
+            QChar ch = sanitized[i];
+            if (ch == '(') {
+                ++depth;
+            } else if (ch == ')') {
+                --depth;
+                if (depth == 0 && i < sanitized.size() - 2) {
+                    encloses = false;
+                    break;
+                }
+                if (depth < 0) {
+                    encloses = false;
+                    break;
+                }
+            }
+        }
+
+        if (encloses && depth == 1) {
+            sanitized = sanitized.mid(1, sanitized.size() - 2);
+            trimmed = true;
+        }
+    }
+
+    if (sanitized.isEmpty()) {
+        return true;
+    }
+
+    const int length = sanitized.size();
     int index = 0;
     bool parsedAny = false;
 
@@ -152,45 +185,50 @@ bool Polynomial::parseFromString(const QString& text) {
 }
 
 QString Polynomial::toExpressionString() const {
-    if (head == nullptr) {
-        return QStringLiteral("0");
-    }
-
     QString result;
     QTextStream stream(&result);
-    Term* current = head;
-    bool first = true;
 
-    while (current != nullptr) {
-        long long coefficient = current->coefficient;
-        long long exponent = current->exponent;
+    stream << '(';
 
-        if (first) {
-            if (coefficient < 0) {
-                stream << '-';
+    if (head == nullptr) {
+        stream << '0';
+    } else {
+        Term* current = head;
+        bool first = true;
+
+        while (current != nullptr) {
+            const long long coefficient = current->coefficient;
+            const long long exponent = current->exponent;
+
+            if (first) {
+                if (coefficient < 0) {
+                    stream << '-';
+                }
+            } else {
+                stream << (coefficient < 0 ? '-' : '+');
             }
-        } else {
-            stream << (coefficient < 0 ? '-' : '+');
-        }
 
-        long long absCoef = coefficient < 0 ? -coefficient : coefficient;
-        bool showCoefficient = !(absCoef == 1 && exponent != 0);
+            const long long absCoef = coefficient < 0 ? -coefficient : coefficient;
+            const bool showCoefficient = !(absCoef == 1 && exponent != 0);
 
-        if (showCoefficient) {
-            stream << absCoef;
-        }
-
-        if (exponent != 0) {
-            stream << 'x';
-            if (exponent != 1) {
-                stream << '^' << exponent;
+            if (exponent == 0) {
+                stream << absCoef;
+            } else {
+                if (showCoefficient) {
+                    stream << absCoef;
+                }
+                stream << 'x';
+                if (exponent != 1) {
+                    stream << '^' << exponent;
+                }
             }
-        }
 
-        first = false;
-        current = current->next;
+            first = false;
+            current = current->next;
+        }
     }
 
+    stream << ')';
     return result;
 }
 

--- a/polynomial.cpp
+++ b/polynomial.cpp
@@ -194,6 +194,25 @@ QString Polynomial::toExpressionString() const {
     return result;
 }
 
+QString Polynomial::toSequenceString() const {
+    int termCount = countTerms();
+    if (termCount == 0) {
+        return QStringLiteral("0");
+    }
+
+    QString result = QString::number(termCount);
+    Term* current = head;
+    while (current != nullptr) {
+        result.append(',');
+        result.append(QString::number(current->coefficient));
+        result.append(',');
+        result.append(QString::number(current->exponent));
+        current = current->next;
+    }
+
+    return result;
+}
+
 Polynomial Polynomial::add(const Polynomial& other) const {
     Polynomial output;
     Term* lhs = head;

--- a/polynomial.cpp
+++ b/polynomial.cpp
@@ -200,13 +200,13 @@ QString Polynomial::toSequenceString() const {
         return QStringLiteral("0");
     }
 
-    QString result = QString::number(termCount);
+    QString result;
+    QTextStream stream(&result);
+    stream << termCount;
+
     Term* current = head;
     while (current != nullptr) {
-        result.append(',');
-        result.append(QString::number(current->coefficient));
-        result.append(',');
-        result.append(QString::number(current->exponent));
+        stream << ' ' << current->coefficient << ' ' << current->exponent;
         current = current->next;
     }
 

--- a/polynomial.h
+++ b/polynomial.h
@@ -1,7 +1,6 @@
 #ifndef POLYNOMIAL_H
 #define POLYNOMIAL_H
 
-#include <cmath>
 #include <string>
 
 #include <QString>

--- a/polynomial.h
+++ b/polynomial.h
@@ -1,0 +1,44 @@
+#ifndef POLYNOMIAL_H
+#define POLYNOMIAL_H
+
+#include <cmath>
+#include <string>
+
+#include <QString>
+
+using namespace std;
+
+class Polynomial {
+public:
+    Polynomial();
+    explicit Polynomial(const QString& text);
+    explicit Polynomial(const string& text);
+    Polynomial(const Polynomial& other);
+    Polynomial(Polynomial&& other) noexcept;
+    Polynomial& operator=(const Polynomial& other);
+    Polynomial& operator=(Polynomial&& other) noexcept;
+    ~Polynomial();
+
+    bool isEmpty() const;
+    bool parseFromString(const QString& text);
+    QString toExpressionString() const;
+    Polynomial add(const Polynomial& other) const;
+    Polynomial subtract(const Polynomial& other) const;
+    long double evaluate(long double x) const;
+
+private:
+    struct Term {
+        long long coefficient;
+        long long exponent;
+        Term* next;
+    };
+
+    Term* head;
+
+    void clear();
+    void copyFrom(const Polynomial& other);
+    int countTerms() const;
+    void insertTerm(long long coefficient, long long exponent);
+};
+
+#endif // POLYNOMIAL_H

--- a/polynomial.h
+++ b/polynomial.h
@@ -40,6 +40,7 @@ private:
     void copyFrom(const Polynomial& other);
     int countTerms() const;
     void insertTerm(long long coefficient, long long exponent);
+    static long double power(long double base, long long exponent);
 };
 
 #endif // POLYNOMIAL_H

--- a/polynomial.h
+++ b/polynomial.h
@@ -22,6 +22,7 @@ public:
     bool isEmpty() const;
     bool parseFromString(const QString& text);
     QString toExpressionString() const;
+    QString toSequenceString() const;
     Polynomial add(const Polynomial& other) const;
     Polynomial subtract(const Polynomial& other) const;
     long double evaluate(long double x) const;


### PR DESCRIPTION
## Summary
- rework the Polynomial parser to consume algebraic expressions like 3+2x+3x^4-340x^34 while keeping the linked list backend
- add expression-style formatting for displaying polynomials in the Qt interface
- update the main window prompts so users enter the new expression syntax

## Testing
- ❌ `cmake -S . -B build` (fails: Qt development packages are unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e5de6637108320837deaa32cf7c189